### PR TITLE
Fixed WinBase.h override UTexture2D::UpdateResource (UE 4.17)

### DIFF
--- a/AR/Source/AR/Private/ARTarget.cpp
+++ b/AR/Source/AR/Private/ARTarget.cpp
@@ -45,6 +45,10 @@
 #include "ARTarget.h"
 #include "FileManagerGeneric.h"
 
+// Fix WinBase.h override
+#undef UpdateResource
+#define UpdateResource UpdateResource
+
 DEFINE_LOG_CATEGORY_STATIC(LogARToolKits, Log, All);
 
 AARTarget::AARTarget()

--- a/AR/Source/AR/Private/ARToolKit.cpp
+++ b/AR/Source/AR/Private/ARToolKit.cpp
@@ -52,6 +52,10 @@ DEFINE_LOG_CATEGORY_STATIC(LogARToolKit, Log, All);
 #define error(txt) GEngine->AddOnScreenDebugMessage(-1,10,FColor::Red, txt)
 #define warning(txt) GEngine->AddOnScreenDebugMessage(-1,10,FColor::Yellow, txt)
 
+// Fix WinBase.h override
+#undef UpdateResource
+#define UpdateResource UpdateResource
+
 //--- ANDROID JAVA CUSTOM CALLS-------------------------
 #if PLATFORM_ANDROID
 #include <android/log.h>


### PR DESCRIPTION
A Windows Kit header is causing a define making the function UpdateResource not being able to be called properly. 

```
-> WinBase.h Ln 3814
#ifdef UNICODE
#define UpdateResource  UpdateResourceW
#else
#define UpdateResource  UpdateResourceA
#endif // !UNICODE
```
This change should make the plugin recompile with new UE versions on Windows.

